### PR TITLE
Xcert upgrade proposal

### DIFF
--- a/contracts/tokens/Xcert.sol
+++ b/contracts/tokens/Xcert.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.4.23;
+pragma experimental ABIEncoderV2;
 
 import "../../node_modules/@0xcert/ethereum-erc721/contracts/math/SafeMath.sol";
 import "../../node_modules/@0xcert/ethereum-erc721/contracts/ownership/Ownable.sol";
@@ -12,11 +13,22 @@ contract Xcert is NFTokenMetadata {
   using SafeMath for uint256;
   using AddressUtils for address;
 
+  /**
+   * @dev A serial number representing 0xcert protocol convention.
+   */
+  uint256 private nftConvention;
+
   /*
    * @dev Maps NFT ID to proof.
-   * @notice The Proof array for every token must include one or more items.
+   * @notice The proof array for every token must include one or more items.
    */
   mapping (uint256 => string[]) internal idToProof;
+
+  /*
+   * @dev Maps NFT ID to metadata.
+   * @notice The metadata array holds metadata items as a sequence.
+   */
+  mapping (uint256 => string[]) internal idToMetadata;
 
   /*
    * @dev Maps authorized addresses to mint.
@@ -25,7 +37,7 @@ contract Xcert is NFTokenMetadata {
 
   /*
    * @dev Emits when an address is authorized to mint new NFT or the authorization is revoked.
-   * The _target can mint new NFTokens.
+   * The _target can mint new NFTs.
    * @param _target Address to set authorized state.
    * @patam _authorized True if the _target is authorised, false to revoke authorization.
    */
@@ -46,37 +58,54 @@ contract Xcert is NFTokenMetadata {
    * @dev Contract constructor.
    * @param _name A descriptive name for a collection of NFTs.
    * @param _symbol An abbreviated name for NFT.
+   * @param _convention A convention serial number for NFT.
    */
   constructor(
     string _name,
-    string _symbol
+    string _symbol,
+    uint256 _convention
   )
     NFTokenMetadata(_name, _symbol)
     public
   {
     supportedInterfaces[0x355d09e9] = true; // Xcert
+    nftConvention = _convention;
+  }
+
+  /**
+   * @dev Returns a serial number representing 0xcert protocol convention.
+   */
+  function convention()
+    external
+    view
+    returns (uint256 _convention)
+  {
+    _convention = nftConvention;
   }
 
   /*
    * @dev Mints a new NFT.
    * @param _to The address that will own the minted NFT.
    * @param _id The NFT to be minted by the msg.sender.
-   * @param _proof Cryptographic asset imprint.
+   * @param _metadata An array of metadata items.
+   * @param _proofs An array if cryptographic asset imprints.
    * @param _uri An URI pointing to NFT metadata (optional, max length 2083).
    */
   function mint(
     address _to,
     uint256 _id,
-    string _proof,
+    string[] _metadata,
+    string[] _proofs,
     string _uri
   )
     external
     canMint()
   {
-    require(bytes(_proof).length > 0);
+    require(bytes(_proofs[0]).length > 0);
     super._mint(_to, _id);
     super._setTokenUri(_id, _uri);
-    idToProof[_id].push(_proof);
+    idToMetadata[_id] = _metadata;
+    idToProof[_id] = _proofs;
   }
 
   /*
@@ -92,6 +121,23 @@ contract Xcert is NFTokenMetadata {
     returns (string)
   {
     return idToProof[_tokenId][idToProof[_tokenId].length.sub(1)];
+  }
+
+  /*
+   * @dev Gets metadata for NFT token.
+   * @param _tokenId Id of the NFT.
+   * @param _index Metadata position.
+   */
+  function tokenMetadata(
+    uint256 _tokenId,
+    uint256 _index
+  )
+    validNFToken(_tokenId)
+    external
+    view
+    returns (string)
+  {
+    return idToMetadata[_tokenId][_index];
   }
 
   /*


### PR DESCRIPTION
This is a very quick proposal that adds:
* Xcert allows a single asset by exposing the convention serial number.
* Xcert includes metadata for use in atomic swaps.

Further discussion is expected.